### PR TITLE
PR for optimizing T count for all states in qasm format

### DIFF
--- a/src/Feynman/Frontend/OpenQASM/Syntax.hs
+++ b/src/Feynman/Frontend/OpenQASM/Syntax.hs
@@ -431,7 +431,7 @@ applyOpt opt (QASM ver stmts) = QASM ver $ optStmts stmts
         applyToStmts stmts =
           let (gates, gateMap, qubitMap) = foldl' stmtToGate ([], Map.empty, Map.empty) stmts
               vars                       = ids gates
-              gates'                     = opt vars [] (reverse gates)
+              gates'                     = opt vars vars (reverse gates)
           in
             map (gateToStmt (gateMap, qubitMap)) gates'
 
@@ -439,7 +439,7 @@ applyOpt opt (QASM ver stmts) = QASM ver $ optStmts stmts
         applyToUExps inp uexps =
           let (gates, gateMap, qubitMap) = foldl' uexpToGate ([], Map.empty, Map.empty) uexps
               vars                       = ids gates
-              gates'                     = opt vars inp (reverse gates)
+              gates'                     = opt vars vars (reverse gates)
           in
             map (gateToUExp (gateMap, qubitMap)) gates'
 

--- a/src/Feynman/Frontend/OpenQASM/Syntax.hs
+++ b/src/Feynman/Frontend/OpenQASM/Syntax.hs
@@ -411,8 +411,8 @@ inline (QASM ver stmts) = QASM ver . snd . foldl f (Map.empty, []) $ stmts
           Nothing         -> [CallGate v e xs]
 
 -- Provides an optimization interface for the main IR
-applyOpt :: ([ID] -> [ID] -> [Primitive] -> [Primitive]) -> QASM -> QASM
-applyOpt opt (QASM ver stmts) = QASM ver $ optStmts stmts
+applyOpt :: ([ID] -> [ID] -> [Primitive] -> [Primitive]) -> Bool -> QASM -> QASM
+applyOpt opt pureCircuit (QASM ver stmts) = QASM ver $ optStmts stmts
   where optStmts stmts =
           let (hdr, body) = foldl' optStmt ([], []) stmts in
             reverse hdr ++ applyToStmts (reverse body)
@@ -431,7 +431,8 @@ applyOpt opt (QASM ver stmts) = QASM ver $ optStmts stmts
         applyToStmts stmts =
           let (gates, gateMap, qubitMap) = foldl' stmtToGate ([], Map.empty, Map.empty) stmts
               vars                       = ids gates
-              gates'                     = opt vars vars (reverse gates)
+              inputs                     = if pureCircuit then vars else []
+              gates'                     = opt vars inputs (reverse gates)
           in
             map (gateToStmt (gateMap, qubitMap)) gates'
 
@@ -439,7 +440,8 @@ applyOpt opt (QASM ver stmts) = QASM ver $ optStmts stmts
         applyToUExps inp uexps =
           let (gates, gateMap, qubitMap) = foldl' uexpToGate ([], Map.empty, Map.empty) uexps
               vars                       = ids gates
-              gates'                     = opt vars vars (reverse gates)
+              inputs                     = if pureCircuit then vars else inp
+              gates'                     = opt vars inputs (reverse gates)
           in
             map (gateToUExp (gateMap, qubitMap)) gates'
 

--- a/tools/FeynOpt.hs
+++ b/tools/FeynOpt.hs
@@ -133,21 +133,21 @@ benchVerif False = Nothing
 
 {- QASM -}
 
-qasmPass :: Pass -> (QASM -> QASM)
-qasmPass pass = case pass of
+qasmPass :: Bool -> Pass -> (QASM -> QASM)
+qasmPass pureCircuit pass = case pass of
   Triv      -> id
   Inline    -> inline
   MCT       -> inline
   CT        -> inline
   Simplify  -> id
-  Phasefold -> applyOpt phaseFold
-  Statefold -> applyOpt stateFold
-  CNOTMin   -> applyOpt minCNOT
-  TPar      -> applyOpt tpar
-  Cliff     -> applyOpt (\_ _ -> simplifyCliffords)
+  Phasefold -> applyOpt phaseFold pureCircuit
+  Statefold -> applyOpt stateFold pureCircuit
+  CNOTMin   -> applyOpt minCNOT pureCircuit
+  TPar      -> applyOpt tpar pureCircuit
+  Cliff     -> applyOpt (\_ _ -> simplifyCliffords) pureCircuit
 
-runQASM :: [Pass] -> Bool -> String -> String -> IO ()
-runQASM passes verify fname src = do
+runQASM :: [Pass] -> Bool -> Bool -> String -> String -> IO ()
+runQASM passes verify pureCircuit fname src = do
   start <- getCPUTime
   end   <- parseAndPass `seq` getCPUTime
   case parseAndPass of
@@ -166,7 +166,7 @@ runQASM passes verify fname src = do
           let qasm   = parse . lexer $ src
           symtab <- check qasm
           let qasm'  = desugar symtab qasm -- For correct gate counts
-          qasm'' <- return $ foldr qasmPass qasm' passes
+          qasm'' <- return $ foldr (qasmPass pureCircuit) qasm' passes
           return (qasm', qasm'')
 
 {- Main program -}
@@ -177,7 +177,10 @@ printHelp = mapM_ putStrLn lines
           "Feynman -- quantum circuit toolkit",
           "Written by Matthew Amy",
           "",
-          "Run with feynopt [passes] (<circuit>.(qc | qasm) | Small | Med | All)",
+          "Run with feynopt [options] [passes] (<circuit>.(qc | qasm) | Small | Med | All)",
+          "",
+          "Options:",
+          "  -purecircuit\tPerform qasm passes assuming the initial state (of qubits) is unknown",
           "",
           "Transformation passes:",
           "  -inline\tInline all sub-circuits",
@@ -203,33 +206,34 @@ printHelp = mapM_ putStrLn lines
           "WARNING: Using \"-verify\" with \"All\" may crash your computer without first setting",
           "         user-level memory limits. Use with caution"
           ]
-          
 
-parseArgs :: [Pass] -> Bool -> [String] -> IO ()
-parseArgs passes verify []     = printHelp
-parseArgs passes verify (x:xs) = case x of
+
+parseArgs :: [Pass] -> Bool -> Bool -> [String] -> IO ()
+parseArgs passes verify pureCircuit []     = printHelp
+parseArgs passes verify pureCircuit (x:xs) = case x of
   "-h"           -> printHelp
-  "-inline"      -> parseArgs (Inline:passes) verify xs
-  "-mctExpand"   -> parseArgs (MCT:passes) verify xs
-  "-toCliffordT" -> parseArgs (CT:passes) verify xs
-  "-simplify"    -> parseArgs (Simplify:passes) verify xs
-  "-phasefold"   -> parseArgs (Phasefold:Simplify:passes) verify xs
-  "-statefold"   -> parseArgs (Statefold:Simplify:passes) verify xs
-  "-cnotmin"     -> parseArgs (CNOTMin:Simplify:passes) verify xs
-  "-tpar"        -> parseArgs (TPar:Simplify:passes) verify xs
-  "-clifford"    -> parseArgs (Cliff:Simplify:passes) verify xs
-  "-decompile"   -> parseArgs (Decompile:passes) verify xs
-  "-O2"          -> parseArgs (Simplify:Phasefold:Simplify:passes) verify xs
-  "-O3"          -> parseArgs (Simplify:Phasefold:Statefold:Simplify:passes) verify xs
-  "-verify"      -> parseArgs passes True xs
+  "-purecircuit" -> parseArgs (passes) verify True xs
+  "-inline"      -> parseArgs (Inline:passes) verify pureCircuit xs
+  "-mctExpand"   -> parseArgs (MCT:passes) verify pureCircuit xs
+  "-toCliffordT" -> parseArgs (CT:passes) verify pureCircuit xs
+  "-simplify"    -> parseArgs (Simplify:passes) verify pureCircuit xs
+  "-phasefold"   -> parseArgs (Phasefold:Simplify:passes) verify pureCircuit xs
+  "-statefold"   -> parseArgs (Statefold:Simplify:passes) verify pureCircuit xs
+  "-cnotmin"     -> parseArgs (CNOTMin:Simplify:passes) verify pureCircuit xs
+  "-tpar"        -> parseArgs (TPar:Simplify:passes) verify pureCircuit xs
+  "-clifford"    -> parseArgs (Cliff:Simplify:passes) verify pureCircuit xs
+  "-decompile"   -> parseArgs (Decompile:passes) verify pureCircuit xs
+  "-O2"          -> parseArgs (Simplify:Phasefold:Simplify:passes) verify pureCircuit xs
+  "-O3"          -> parseArgs (Simplify:Phasefold:Statefold:Simplify:passes) verify pureCircuit xs
+  "-verify"      -> parseArgs passes True pureCircuit xs
   "VerBench"     -> runBenchmarks (benchPass [CNOTMin,Simplify]) (benchVerif True) benchmarksMedium
 --  "VerAlg"       -> runVerSuite
   "Small"        -> runBenchmarks (benchPass passes) (benchVerif verify) benchmarksSmall
   "Med"          -> runBenchmarks (benchPass passes) (benchVerif verify) benchmarksMedium
   "All"          -> runBenchmarks (benchPass passes) (benchVerif verify) benchmarksAll
   f | (drop (length f - 3) f) == ".qc" -> B.readFile f >>= runDotQC passes verify f
-  f | (drop (length f - 5) f) == ".qasm" -> readFile f >>= runQASM passes verify f
+  f | (drop (length f - 5) f) == ".qasm" -> readFile f >>= runQASM passes verify pureCircuit f
   f | otherwise -> putStrLn ("Unrecognized option \"" ++ f ++ "\"") >> printHelp
 
 main :: IO ()
-main = getArgs >>= parseArgs [] False
+main = getArgs >>= parseArgs [] False False


### PR DESCRIPTION
The function `opt:: ([ID] -> [ID] -> [Primitive] -> [Primitive])` takes a set of qubits, a set of inputs, and a circuit representation, and returns an optimized circuit. When called for qasm inputs, I ensure that the set of inputs is equal to the set of qubits, thus treating all of the qubits equally in an unknown state and directing the optimization to work for all inputs.


If you think this looks good, I will go ahead and add a flag named `-nz` ("no zeroes") that decides between the two alternatives.