### PR TITLE
Fix: Add missing imports for GHC 9.6.7 compatibility

### DIFF
--- a/src/Feynman/Optimization/StateFold.hs
+++ b/src/Feynman/Optimization/StateFold.hs
@@ -24,6 +24,7 @@ import Data.Map.Strict (Map, (!))
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Control.Monad (msum, liftM)
 import Control.Monad.State.Strict hiding (join)
 import Data.Bits
 import Data.Coerce (coerce)


### PR DESCRIPTION
# Fix: Add missing imports for GHC 9.6.7 compatibility

Fixes #20

## Summary

Adds explicit imports for `msum` and `liftM` from `Control.Monad` in `StateFold.hs` to fix build errors with GHC 9.6.7+.

## Solution

Added explicit import:
```haskell
import Control.Monad (msum, liftM)
```

## Testing

✅ Builds successfully with GHC 9.6.7  
✅ All 34 modules compile without errors  